### PR TITLE
add BIP39 nis1 test vectors

### DIFF
--- a/nis1/6.test-hd-derivation.json
+++ b/nis1/6.test-hd-derivation.json
@@ -1,0 +1,1926 @@
+{
+  "public_net": [
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "passphrase": "",
+      "seed": "5EB00BBDDCF069084889A8AB9155568165F5C453CCB85E70811AAED6F6DA5FC19A5AC40B389CD370D086206DEC8AA6C43DAEA6690F20AD3D8D48B2D2CE9E38E4",
+      "rootPublicKey": "1946E430AB6CA462394AC3CA40FC2F924058B4885B2840A4C692980D2DF0BFB3",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "4AA3AA159A6417C8986282F4D4D217D4F463298D4E672E16BFC2C271EDA1A954"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "27A0DCF3D52B31790C91180C7596523CC3121A0CF0C39C6D7D3BDAEA3022C755"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "79679B9C8AE6055A046C032B9291F774D8357C05BB1D2E30859209A00CB6C04D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank yellow",
+      "passphrase": "",
+      "seed": "878386EFB78845B3355BD15EA4D39EF97D179CB712B77D5C12B6BE415FFFEFFE5F377BA02BF3F8544AB800B955E51FBFF09828F682052A20FAA6ADDBBDDFB096",
+      "rootPublicKey": "A490F34F3BFF87EE2FBA681CAAD465E4096970CC168E041AEAE90588C55E8FDE",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "B61B6E9BF6C0FEF12D56792FF4B8F92718E90CB7767FEE51170BA406133E0D9A"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "15465F30C765E27B9206802F49412741D72F976562FB5900B126699DE63E9C4A"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "5D06DF8D22429A270FAC44F39F888911788F1BC341F722D6F887715E17745D8C"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+      "passphrase": "",
+      "seed": "77D6BE9708C8218738934F84BBBB78A2E048CA007746CB764F0673E4B1812D176BBB173E1A291F31CF633F1D0BAD7D3CF071C30E98CD0688B5BCCE65ECACEB36",
+      "rootPublicKey": "EF457C4B8B746A46FF05DC821266A5A8DFCA95AE831ACF96A99AC12CB2EA0701",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "94BE4C16F94D76732E7CC19CB67B59C128047D63ED0EAF6E7364DBAED91D4FF5"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "7DDA70F3460DA861700D489500CC0E749653C431EBE9A842E555A420CBD1E818"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "C2CE84A8BFC9831BE9AAD19A83230F29F58A436D0057375C879F4A3BCF2B4746"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+      "passphrase": "",
+      "seed": "B6A6D8921942DD9806607EBC2750416B289ADEA669198769F2E15ED926C3AA92BF88ECE232317B4EA463E84B0FCD3B53577812EE449CCC448EB45E6F544E25B6",
+      "rootPublicKey": "0FB2631293D992A997051D79A8DDC9479AEA051F97E0ADB0123CBD5734231224",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "49E82637A8647759D7D72DAEA3C197C6592F187C2D9096E31D6F35B970F593D2"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "AE987B8133036084D2413FBD25F2AA0A6CC6760999E6DB419C2517E720D550DB"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "0EB7C8EEB335941BCE63A1309DD7C47D5A70010583158B619A67076E3B1CA0EA"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+      "passphrase": "",
+      "seed": "4975BB3D1FAF5308C86A30893EE903A976296609DB223FD717E227DA5A813A34DC1428B71C84A787FC51F3B9F9DC28E9459F48C08BD9578E9D1B170F2D7EA506",
+      "rootPublicKey": "8ABB4CC0EFB1B4FD39E2BD2CC4BD7CA9A7BD549BDF4F6B30A71506E6402E290F",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "79B71907795C37FEBC267512E36028F4B564CAC4823124925BBCB20E738FA496"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "6BE477691B7362D7A2B083F1FCC92776577A42416C116C32FD050332986EDEF3"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "3F0B62F038465ED8410E9F2CD50D2C1BF24B1FFD5D838DBDE9DF1EABC8AD3A18"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+      "passphrase": "",
+      "seed": "B059400CE0F55498A5527667E77048BB482FF6DAA16C37B4B9E8AF70C85B3F4DF588004F19812A1A027C9A51E5E94259A560268E91CD10E206451A129826E740",
+      "rootPublicKey": "A572997EAF42DF29B7D043A03CE675BA5E5BB0D891519ED06F8176C998084F52",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "67BBC55F1D572C4B790BE263D223212DCE23254AFD4B5873E310C704B5429EDE"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "9A540888F9BD4256BD677A04E3FEC40F970D456BD2DBBE53E7F115C6F33DFAB3"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "537575E6785CE2B40D6243DDAEB9AE7DE41EDBF1CF654D33DBE4D13BA7C92126"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+      "passphrase": "",
+      "seed": "04D5F77103510C41D610F7F5FB3F0BADC77C377090815CEE808EA5D2F264FDFABF7C7DED4BE6D4C6D7CDB021BA4C777B0B7E57CA8AA6DE15AEB9905DBA674D66",
+      "rootPublicKey": "A3685884F1B460735E3062D5554FADE7855C7F3AB55A9F32991E18A97CF2607D",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "1DF0BDF54EF8F0EEA01CDCFB18C45E1307CBBA0906482823C80F1FE2FA3393FF"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "14A254A028F38364AFE6D6F4C5F8C08918F388D1D9534DDFE561BBFCB17A119A"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "05A0206E6A9ADB692593ADF9F6B301965602D18CFC0983B29B5F61443C2E0541"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+      "passphrase": "",
+      "seed": "D2911131A6DDA23AC4441D1B66E2113EC6324354523ACFA20899A2DCB3087849264E91F8EC5D75355F0F617BE15369FFA13C3D18C8156B97CD2618AC693F759F",
+      "rootPublicKey": "710DA9C40BBA433CFF11F26B217464F2CF0786A91B9C9E9964FB1C547A37A87B",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "761851C5F4D288B60FE3157EAE46EAC83D6817E41EB6C1269FB7C87738937AD2"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "6D12679AEED8BCE3DCC110046E2960F1EDCC8CBC554A92CB49569AFF303E10CD"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "459D958B850D7B517AE8560BA62D1C7701C7B2AB2CF2D4306CCAF7FC74A63A49"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      "passphrase": "",
+      "seed": "408B285C123836004F4B8842C89324C1F01382450C0D439AF345BA7FC49ACF705489C6FC77DBD4E3DC1DD8CC6BC9F043DB8ADA1E243C4A0EAFB290D399480840",
+      "rootPublicKey": "AB96B04A3731993D08CDC049BA8C3D15B86A53D0690FFF57D880C27C23BB2250",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "58892BC737B493D837D7F7EC4519371B9498F23BBC7F2A2A10DE11A70E7BCF84"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "5FC4FCADABD69819847BC6E366D892F6E6A8B7277D16353ED35F93AC6D843EE7"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "5EB5397223D28E087725A46C033FA90A7B8480BE5750B77B08C4B8BBEA35082E"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+      "passphrase": "",
+      "seed": "761914478EBF6FE16185749372E91549361AF22B386DE46322CF8B1BA7E92E80C4AF05196F742BE1E63AAB603899842DDADF4E7248D8E43870A4B6FF9BF16324",
+      "rootPublicKey": "BBE6CCCAFCE0CCAB61103028EC9D75713BC065ECA88264688D1BB6DF939598E8",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "63E98F578E10E0BBB192A2004E20B4F7C4FFD0BD8FD1AD90C205A4583A36A35B"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "8942AA67082C1A16807447BBB8E2AF9A176933A6536164EDB54D12F80953808E"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "E79977D47EEB4EC1A9CB0B335409A076B38B00A442F8236C97B7677FBAEB4912"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+      "passphrase": "",
+      "seed": "848BBE19CAD445E46F35FD3D1A89463583AC2B60B5EB4CFCF955731775A5D9E17A81A71613FED83F1AE27B408478FDEC2BBC75B5161D1937AA7CDF4AD686EF5F",
+      "rootPublicKey": "1F83065B3EEE4FC911C15C4F2BBBE1DE9014B41DE1211E26EE77ECEF4A0030D1",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "E0E9004A286070DB711AC0A16CF8F00870F1760A03B9CF74E0E7DAD21F23D432"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "DAA9F6395DA340BC512C12B2E1D1076F38A674B1BAC071C1A2CC87022CD33D74"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "97238CC8FEF904915C0AF4FA956572EEC021F8BCD82FC75DB12F7DD25CE296B5"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+      "passphrase": "",
+      "seed": "E28A37058C7F5112EC9E16A3437CF363A2572D70B6CEB3B6965447623D620F14D06BB321A26B33EC15FCD84A3B5DDFD5520E230C924C87AAA0D559749E044FEF",
+      "rootPublicKey": "FE571EC4B0D2D99D915FA46EBED88D84009E8C91776578212B617DC8B9513FD6",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "F3B806ADF6732BE30E5DE32C63CA966650424B4995C442BD2F78BCF73D6A0FE8"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "0DC202B9459AB49447461B641F80E43C08EF684ABEBFFE8A809DE59200575D78"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "0D5930E99EBC85043160AA39FB904281B5614BA6BABFF84D86AECEE49150FD2D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+      "passphrase": "",
+      "seed": "E2F88A043776C828063D4C3C97173944D32CF847A925B6E40B0B8BD0B4BEAD3BA734BDDA5250D4698B310A71C9934E1A48E562315CE22BF85F89459DF0E73A6C",
+      "rootPublicKey": "45846FF527AFF9BCE616C0B1A6E0D373875D952AB52BF81EF8547DDE53DEA064",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "CDC04C15D6E44AAA8E629ED8AFC485C4DAE4D8717EE6B51182025F5F9CD87A1C"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "213E35A33F91F07D1D3DB46400742C2B05B3AE1E057151C99472487B5A61E25C"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "8359325C4DE4FB67E4DA1B703F906C193CD2BCF7254A30CA0EAE1F4875042B6B"
+        }
+      ]
+    },
+    {
+      "mnemonic": "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+      "passphrase": "",
+      "seed": "31736B4F31612ECE84404C74A5D3B938A092480EB89C11B81491F1A3657EB2FE50024610FBE814DF55913A87EF741020FCF076A75A29AEA0ABA638126BA4C8BB",
+      "rootPublicKey": "EAC40A4E4E0A2956EA6E78B351F8CD51CF7F48737C471F756C01E2728C0E39AD",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "F8960971939C41524AD7712D3837E73CC30C34772D2D7EBEEC82367DEAE4325F"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "85DE516D51D86178A8E4107548B926C52268D8B8B4FEB382A8EC3F101AE3AFD4"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "2148F1839378CB2F5448CE8BB897739B6EFBE689ABE7A6B6E44770F63FFBF49D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+      "passphrase": "",
+      "seed": "17E4B5661796EEFF8904550F8572289317ECE7C1CC1316469F8F4C986C1FFD7B9F4C3AEAC3E1713FFC21FA33707D09D57A2ECE358D72111EF7C7658E7B33F2D5",
+      "rootPublicKey": "30BA1AA120344D55A9C24BCD221DC09C0361C081B84EBED015C554F446854BB6",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "6C42BFAD2199CCB5C64E59868CC7A3F2AD29BDDCEB9754157DF136535E6B5EBA"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "782FF2375F75524106356092B4EE4BA098D28CF6571F1643867B9A11AEF509C6"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "20EEEFCAE026EBB3C3C51E9AF86A97AA146B34A5463CFE468B37C3CB49682408"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scheme spot photo card baby mountain device kick cradle pact join borrow",
+      "passphrase": "",
+      "seed": "00E1E39A39E23735ADAB690D0FFBEFDA6CACC063B4A5FCC605DE060BD370ADC54C94370D966B9A3FAE5ED16BD58A02224CBEFCA4146A083951B70BE2A2CE3DCC",
+      "rootPublicKey": "A5AE606DD5F0D8218BF503FB2B57B3A6D3C76A332377101BEB00EBB2C8C81022",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "6565CDA597ABD771F894AFF2AE981E44F249B89948340134FFB7F4174CA02FC9"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "06BD82F5684019F042EBF828FD27ECF449C941D7CBCEB7BA641F4642D31CCEE0"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "21C1E4F5D83E4A270BBA3E36BE46DA53298A054A0DB98E8E35B4794C3775B00F"
+        }
+      ]
+    },
+    {
+      "mnemonic": "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+      "passphrase": "",
+      "seed": "E893FC34FA2A78CEAAEA78C246B69257AD283FA538D88F3C4520BEB618A2062B8EC4920ED1793FFF6AD443523ED18C03DA433004D0A1E9497E194621607BC9E2",
+      "rootPublicKey": "7A8222ECD77EE0E7A9BB09EFC2F4FC285614462EBE430C457E6012A4388860CB",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "F9D05DEBEF744A9766BC6A37F56EF1AA6522A764CF9314383A96D73C077AB487"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "66BE11DB4F2DFBD1010E610895EACB713F6C73FC57963B27880565E1FBB2CC7F"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "82E61D5627215E501E17F38F6A87EA0087E8379C7C3CDE41627F125154674BB9"
+        }
+      ]
+    },
+    {
+      "mnemonic": "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+      "passphrase": "",
+      "seed": "3E066D7DEE2DBF8FCD3FE240A3975658CA118A8F6F4CA81CF99104944604B05A5090A79D99E545704B914CA0397FEDB82FD00FD6A72098703709C891A065EE49",
+      "rootPublicKey": "BD31401335F76E04C31F6E99B5BE438E6CA987E0F5F450E4E845BE566FA73DA0",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "EFADBB381CBEC192ECB48B4F2286CBFF751559FDA90CD576D117FBB4D4C0EE36"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "C42B285FA9DAB7C1BDC34EB13445C58966B007F70499551C2B29E57BC71ECE3E"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "6B1F6D618369B0067C116D6BA65948FCEA1E1AE367CFE3C123EC198974115305"
+        }
+      ]
+    },
+    {
+      "mnemonic": "cat swing flag economy stadium alone churn speed unique patch report train",
+      "passphrase": "",
+      "seed": "7EA73B3A398F8A71F7DDE589D972B0358D3FA8B9E91317ECC544E42752B1BB251A1926B1F4C69EEC0A80C0396AA0F7DF29F7D73411D3106EBA539F3D584FCDF8",
+      "rootPublicKey": "E9222C652FC20E338874406554DE00ADD62B69F2A43FB6B30E731311724E97AC",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "B47C5FECD6B1903DAB58D15FE92073E63A89D6DE58D24CD6F55C5034B0F17BF5"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "92B76713F4023E086EDC73AA7540B2DAD66E4A4F4B3CBA5ED9E840FAB0AB3861"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "05EE56E96AF875DDCA9A922BFC97D692177BD5C884710097D7A9DDCCBCE09260"
+        }
+      ]
+    },
+    {
+      "mnemonic": "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+      "passphrase": "",
+      "seed": "D0CA8861283A7124515E825B7A06DE8E0AD0DD5AC7888013EFE6E3C300D4745BBD2C729F3355D769D23718579E7B735999A8F0B38E22B5BFF45C9085AF449056",
+      "rootPublicKey": "29DA443A7C8B54DD031D31B9B46F1ABE9ACA9AA9B536816B9BAE5F78BDFE5E99",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "5860F3C6254C546AEB2A3727EC490BFCCAC1983716FFF62E359128E1CD4138D6"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "FEBB5FDACD7392F5BFF9574F35EFC9EFF1B5CE078C406E1DC2CBE5C57B2CC9FA"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "69DDFB00D218C7BA97470DB750196F686ED6B9AB599A30EE64E09FC1C7AA109D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+      "passphrase": "",
+      "seed": "FC795BE0C3F18C50DDDB34E72179DC597D64055497ECC1E69E2E56A5409651BC139AAE8070D4DF0EA14D8D2A518A9A00BB1CC6E92E053FE34051F6821DF9164C",
+      "rootPublicKey": "5F19703C36821F5673754044EA108FBBD7EAE38FFDC2B71190F182C67E255822",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "3C09D907616A762B3D549F4AF84580E67B82FBDC4DEF86B769B480AA91601C62"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "B345383148E7A219B438399165D83541947C48B9F2C3FE2605673118F70661D4"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "CD5BB7B1E0A75705BC55D1E312A960D740A665DC8580C74268943C42D6622C01"
+        }
+      ]
+    },
+    {
+      "mnemonic": "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+      "passphrase": "",
+      "seed": "E2D7F9A462875C1325F44F321392EDC8EAAFEBF1547C89D72D10B41B4EE23AF3FB0AB010F39F5CBEA3B3AA671161B58262B6A508BCBE2D34EE272A942534D45F",
+      "rootPublicKey": "D1DDE656E66BBB185373AB84F42BD286C3BADF84651EA2AD006C1EB314E453F8",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "855FE6D5C4E39361BE10271694A6DAF1D60B1443AFB829D6F12D3FEC2FEC716B"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "A80FBB35C0DAE43B66358D41E5DE99B458F2BC3297CAECD9F0ADD537D24809F2"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "A27BDE77C6E7C986659B4323C05EF2841D33CD59C8510D4AA786E4EAA5C19018"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+      "passphrase": "",
+      "seed": "A555426999448DF9022C3AFC2ED0E4AEBFF3A0AC37D8A395F81412E14994EFC960ED168D39A80478E0467A3D5CFC134FEF2767C1D3A27F18E3AFEB11BFC8E6AD",
+      "rootPublicKey": "4124D3C1941586C07EDCBDBED1B7DB107C09A56B8B2A258DDD9E359651F3572F",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "D23A2740B498C7EFD6C1843DBD8899ACC4B88F7640A0753489A3DFF483C081D9"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "694D344400BA5EC64F5DC0DB1A683FA787B15D74BA138C7607386BC5B25BADC6"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "F7430F372422844714D9EF73EDD8EA1B22819090FE5AC316A98F04E238E556D4"
+        }
+      ]
+    },
+    {
+      "mnemonic": "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+      "passphrase": "",
+      "seed": "B873212F885CCFFBF4692AFCB84BC2E55886DE2DFA07D90F5C3C239ABC31C0A6CE047E30FD8BF6A281E71389AA82D73DF74C7BBFB3B06B4639A5CEE775CCCD3C",
+      "rootPublicKey": "006538A4E58402C812DC9A046F5225148BD3FC4EFC84948825E4F7F3116F4B14",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "9E5A10FEF8188631D3C673537E819E624B27425DED94FC1F9B77E09092AFB89C"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "94AD0C9F0CC638B6885A4A7482D5C700D02C9C9A29D90D988D75CC77ACC3D598"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "BB621AB2E0111119FB7F8FD193557EC0B166B54030208BBC5C35602E77347E39"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "passphrase": "TREZOR",
+      "seed": "C55257C360C07C72029AEBC1B53C05ED0362ADA38EAD3E3E9EFA3708E53495531F09A6987599D18264C1E1C92F2CF141630C7A3C4AB7C81B2F001698E7463B04",
+      "rootPublicKey": "7AD06DBDDB30719117113D532238150FCF77ECDB6EB4754A5F98ED4D3CD9185D",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "4348F35A98DF0AC1DC53AB4613DBEF3AC6163446066A9B97DD5720B3C2C7114A"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "C658E70A1980E9495D3BCAFD7AEC5EC0417EE073BD207161D90F8FC7514E68BF"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "F30C8EC3691A61CA8AAA8BFF1AFB79EFAA383BB85E3A9D2A781AB189B8D8D10D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank yellow",
+      "passphrase": "TREZOR",
+      "seed": "2E8905819B8723FE2C1D161860E5EE1830318DBF49A83BD451CFB8440C28BD6FA457FE1296106559A3C80937A1C1069BE3A3A5BD381EE6260E8D9739FCE1F607",
+      "rootPublicKey": "2DF1BA3A3A47D0E2E7CC928C91F9886733B8C4C89B59170C97F682E2328DF457",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "58F43E7B63704C7972D8FC727089DA0173A813B5B714DF706CE067275F119FF1"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "EE75A5741C51A100B9298D88E65CDC24C864360D2DB4DA496D30888A281C5529"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "2F5828D6C8EF6F751CA2D5E7C2706E7A624471F930F998CE89F148739877BF36"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+      "passphrase": "TREZOR",
+      "seed": "D71DE856F81A8ACC65E6FC851A38D4D7EC216FD0796D0A6827A3AD6ED5511A30FA280F12EB2E47ED2AC03B5C462A0358D18D69FE4F985EC81778C1B370B652A8",
+      "rootPublicKey": "670C0A47F164520A99AC03309E71FC2361ED831BCB02DE54F38459BBBA42CA9C",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "E3553C973BCAD8A5C0C875C0436AAD7D071A6568C65593C4EF50A35DA9509D4E"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "38DE1FCC32B0D72DB8A4131FF18277DF47558FDFF8B818299639DECB9598F0CB"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "E93F3C2344B7D46882F38D93103F97F181BFE7E8733D2F36D3A3A9F95CB3E58F"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+      "passphrase": "TREZOR",
+      "seed": "AC27495480225222079D7BE181583751E86F571027B0497B5B5D11218E0A8A13332572917F0F8E5A589620C6F15B11C61DEE327651A14C34E18231052E48C069",
+      "rootPublicKey": "4F46B3A23C0DE9C903B1BF918BE7628B196AB3BF0DA48F3423375838769D71C0",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "740EC55612DEFF2D39F8668A9B65067B5665A0A1E4662F13BF594B8732C6DBFD"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "C495BDF98E5B021EA915CB70686A5874C50DB20A6FC95B359E51A18DF79D9988"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "174BECD3E04310030AC9B2D0FDA88F5F5A772EB9AEDE66EC352C9407915709E5"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+      "passphrase": "TREZOR",
+      "seed": "035895F2F481B1B0F01FCF8C289C794660B289981A78F8106447707FDD9666CA06DA5A9A565181599B79F53B844D8A71DD9F439C52A3D7B3E8A79C906AC845FA",
+      "rootPublicKey": "FBC289808A078ACB5C03045659B2EA564DCBAB9E378C8F6799B4367E4789361B",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "4619C311668C29BD6E887CFF8765D9C3A56E3B27B6B2D149AA8F7C65CD09B022"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "DB9909B8B119A1A5D996E2557758E31516F4330AC676CFDC977AA1B01BDB3B31"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "11B808BAAB9ABA3F220018E2682540E57E8E8084ACCF7EC6A54E4858293D0344"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+      "passphrase": "TREZOR",
+      "seed": "F2B94508732BCBACBCC020FAEFECFC89FEAFA6649A5491B8C952CEDE496C214A0C7B3C392D168748F2D4A612BADA0753B52A1C7AC53C1E93ABD5C6320B9E95DD",
+      "rootPublicKey": "EDB02192139FDC70FF7579A9BA622D4461E65EC3B9B8EA98212FCD726C8DCBAF",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "A53F1A8977B09767563180D2C45669E501EA8AE9D4C88CA6653191CE9C749832"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "A7C45CDC995E409567D98BC8CEF281E857199C28D4A5027773898B096D51E9F6"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "F240F5B247D99F7FD3B35C34ED8971A5EEE334AEFD44845A65C9B6EFFF54040D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+      "passphrase": "TREZOR",
+      "seed": "107D7C02A5AA6F38C58083FF74F04C607C2D2C0ECC55501DADD72D025B751BC27FE913FFB796F841C49B1D33B610CF0E91D3AA239027F5E99FE4CE9E5088CD65",
+      "rootPublicKey": "08271FAE4ED37A63CC5950510A9F8894F86B25D72B0E21509A7AB84E2400E3FF",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "414DE9E0B7C1B824F74342A1944654055F6C33D034C2053381A3AA888E06B54C"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "91391CE99BA6C379693891215D41A76172617310A1F7E2137A88ED8AB3D54C9A"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "78BE812CB2225627E89DEC96469881B2BD22D528082C3955D5F2E28BB25F6146"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+      "passphrase": "TREZOR",
+      "seed": "0CD6E5D827BB62EB8FC1E262254223817FD068A74B5B449CC2F667C3F1F985A76379B43348D952E2265B4CD129090758B3E3C2C49103B5051AAC2EAEB890A528",
+      "rootPublicKey": "5FFC235559503539DC720F7151225B05AA84D1ED289CC5B0097C6D6C21185305",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "9B1B1457F56A428CC7F626A5472AE3667E96CC9271B3ED58B4C6AF73EBC6EEFE"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "CA3130F7419096461F4C8BB5D2CD09E66E42ED541E9C5044F6443D95E646E813"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "C3C3AAE4C702524B7B306C664D509F3BA41900C5544FBDFE251E25A7EC34EA80"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      "passphrase": "TREZOR",
+      "seed": "BDA85446C68413707090A52022EDD26A1C9462295029F2E60CD7C4F2BBD3097170AF7A4D73245CAFA9C3CCA8D561A7C3DE6F5D4A10BE8ED2A5E608D68F92FCC8",
+      "rootPublicKey": "5451901B0BD5DF9C7E2CF87876146246A2D847E57306E302DDD7C9FA8B8C9E9A",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "CD28BF5665447A0D1846D17F2F1DE75EECB41DAC94247613CD65488F67047027"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "6D4AD73D5A2C35CAEE5B93EB973AB7535FA0932988F7EC27405E5984317D1FBB"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "E809C3A8D8ABFCAF6398A0034589A1266F6D8C9E919CA72AF3992F6666E20E98"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+      "passphrase": "TREZOR",
+      "seed": "BC09FCA1804F7E69DA93C2F2028EB238C227F2E9DDA30CD63699232578480A4021B146AD717FBB7E451CE9EB835F43620BF5C514DB0F8ADD49F5D121449D3E87",
+      "rootPublicKey": "32479AAEBB123F993AE9E4239E3C889913F7F2182AE9696B9D95DCA1A55FD5B2",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "596410EC7254D9879BE2D223A640D7C0A05D184809987FBD6E24F53B88756595"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "065508ABFC5CC29F1C40148E83FF39A5C84FE34449240A98AAC3ECECCE4B4229"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "0824016E56FAF2964EEDAF9BFA643DF237018DE8E2B75E6D0F705A251579C520"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+      "passphrase": "TREZOR",
+      "seed": "C0C519BD0E91A2ED54357D9D1EBEF6F5AF218A153624CF4F2DA911A0ED8F7A09E2EF61AF0ACA007096DF430022F7A2B6FB91661A9589097069720D015E4E982F",
+      "rootPublicKey": "6B66F2311E3D3D0E7EE74C95A3D9D33CF3E02C80AA4DFBC5F013EBED2D045229",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "A38960AD3AADDED840FFD70698485B698D4FD0CC53AA275E4BD841BE2C57E6AB"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "22ABBEB64FC97CCEA467F84251EAE620E960CC68E91B2B2A311EDB43961F4CF4"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "DC78A527E3226FC4B98DB22A88A37FEF27127C6033ACB04B03A47C179C307392"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+      "passphrase": "TREZOR",
+      "seed": "DD48C104698C30CFE2B6142103248622FB7BB0FF692EEBB00089B32D22484E1613912F0A5B694407BE899FFD31ED3992C456CDF60F5D4564B8BA3F05A69890AD",
+      "rootPublicKey": "C5A77E179CD82D28CC3878FB560B0636C199AEBB6D6A51A9A92A7EBFD15E66A9",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "5D8DAB9BF6B566DAA5CE4BD9485E5A9E7B992860CBA03A05E4F851D6D11B8A06"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "BFD4B3F202D7F885BA5E8E1DD6774CFC0DF1B898F24173EBCA58CB01B713382E"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "74C5BA13A82A5805426EA29299AB0593B7717B3DFFEAF786A11F5E616451E754"
+        }
+      ]
+    },
+    {
+      "mnemonic": "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+      "passphrase": "TREZOR",
+      "seed": "274DDC525802F7C828D8EF7DDBCDC5304E87AC3535913611FBBFA986D0C9E5476C91689F9C8A54FD55BD38606AA6A8595AD213D4C9C9F9ACA3FB217069A41028",
+      "rootPublicKey": "7F12BA318928F9737E8C43C099160414917BE4C5422DBBFF207FCCBDC62B79BD",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "FA5C248F000AA8F346B34F4772BE224B0DF3E432DC5A25A3E1489C7E867F04AC"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "E32234ADD12DF4C78D1CC2966A6BBF0FE83632F5DAE1532FDE0F481342831421"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "D4B0E8E58564B9E894874519D7AF49CBEFCF3018426F79C44CC542A110A44230"
+        }
+      ]
+    },
+    {
+      "mnemonic": "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+      "passphrase": "TREZOR",
+      "seed": "628C3827A8823298EE685DB84F55CAA34B5CC195A778E52D45F59BCF75ABA68E4D7590E101DC414BC1BBD5737666FBBEF35D1F1903953B66624F910FEEF245AC",
+      "rootPublicKey": "CD455406549E2404FC996D027CF111B4461A04375A6A4A3B6C4D44A932B4FC3C",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "FBC60D474113A67BC21A81B21812EDF4686604891E5F33525408051BE002A01A"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "ABC937910F96D9A392019870C71AF42B6BD8EDFD0B65858238D2D625D4685E4E"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "39CB2F5C805E9D7B253DE4A80C532510D6F08CC0FFCF103DA5C759CB7B3D5952"
+        }
+      ]
+    },
+    {
+      "mnemonic": "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+      "passphrase": "TREZOR",
+      "seed": "64C87CDE7E12ECF6704AB95BB1408BEF047C22DB4CC7491C4271D170A1B213D20B385BC1588D9C7B38F1B39D415665B8A9030C9EC653D75E65F847D8FC1FC440",
+      "rootPublicKey": "0D8147B06AA664684AB144DFA2835B1F296053D520F8B559CF9F4DEBD4EE2A92",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "3BE4759796DD507D6E410CD8C65121E7E42DAC69699A9058E1F7663A390122CE"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "6B288C00800EC9FC0C30F35CEAFC2C5EC4066C2BE622822AAC70D67F215E5E6D"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "1AC159878D327E578C0130767E960C265753CAD5215FC992F1F71C41D00EADA3"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scheme spot photo card baby mountain device kick cradle pact join borrow",
+      "passphrase": "TREZOR",
+      "seed": "EA725895AAAE8D4C1CF682C1BFD2D358D52ED9F0F0591131B559E2724BB234FCA05AA9C02C57407E04EE9DC3B454AA63FBFF483A8B11DE949624B9F1831A9612",
+      "rootPublicKey": "3C85C318EF2A82DAF5BECCF65E0B8611C6E069AA0B241EA33AC28696E8C96B45",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "E0BA01CAAB1F586BBF7255A0CA908F415FCE695FF3B39468D2F939F97B88CF35"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "E6231D9DD6FFA87DED26AB9ACE8FEA1FBE5EF286B12664E69999DD699DEA2B11"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "FAC007FBAAC1891E44F966A1D7C6EA990608EE495172B2B15BF4CE9B2CE500AF"
+        }
+      ]
+    },
+    {
+      "mnemonic": "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+      "passphrase": "TREZOR",
+      "seed": "FD579828AF3DA1D32544CE4DB5C73D53FC8ACC4DDB1E3B251A31179CDB71E853C56D2FCB11AED39898CE6C34B10B5382772DB8796E52837B54468AEB312CFC3D",
+      "rootPublicKey": "60481CD4FC97BCB4AC74D57DF9034CA650046C293FCF20CDDF40207ED6C0D955",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "EFEEEF011228FC6EB54A874091365C90A28140C85C22D5536E6EF3782C083F5C"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "C737DF27F024FEC1EABF6EEC1891345F52D1FE208CDA697F3F2A6BADD773EFBB"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "92987C3F63ADCBEAF68AA3474505C54A39E8D417BC1382D6EB5016C5E6EBAA3A"
+        }
+      ]
+    },
+    {
+      "mnemonic": "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+      "passphrase": "TREZOR",
+      "seed": "72BE8E052FC4919D2ADF28D5306B5474B0069DF35B02303DE8C1729C9538DBB6FC2D731D5F832193CD9FB6AEECBC469594A70E3DD50811B5067F3B88B28C3E8D",
+      "rootPublicKey": "8127A3912B017EFE8C7DFCC9C0F6DD8D46DCA472C314C666C33DA88BC27D1171",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "4DA7AEAE928CDCCB3F87E92B786438A522E923588406369648F3FC0E60436DF7"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "7ABA9409D1170B04E3FFDB10411DADFB85371CC3A9A117AF04B01856ACC1E45D"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "3455AD7BDAC633EADE8705089A28C91F1AD238365ABAF7481EAE6C46DF644F79"
+        }
+      ]
+    },
+    {
+      "mnemonic": "cat swing flag economy stadium alone churn speed unique patch report train",
+      "passphrase": "TREZOR",
+      "seed": "DEB5F45449E615FEFF5640F2E49F933FF51895DE3B4381832B3139941C57B59205A42480C52175B6EFCFFAA58A2503887C1E8B363A707256BDD2B587B46541F5",
+      "rootPublicKey": "EE3B4E609064B16C43DF1FE239B7F2D331F94736D564A0CD257ABC2AA21245A2",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "117B3A2D3ABC25AFF62825338A950D3ACCA91757351FD5BDFDED1FA32C07C759"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "4C006B902DFBD6D0793E9B89820236335E026EEA10C920E6146E14461142D5F9"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "32007FFAEE658107CC34E556A2624C108FAA36A219FB423AFBF9FDD0F0B11140"
+        }
+      ]
+    },
+    {
+      "mnemonic": "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+      "passphrase": "TREZOR",
+      "seed": "4CBDFF1CA2DB800FD61CAE72A57475FDC6BAB03E441FD63F96DABD1F183EF5B782925F00105F318309A7E9C3EA6967C7801E46C8A58082674C860A37B93EDA02",
+      "rootPublicKey": "45AFE2F6FB864E4F46CAA4E5064CCA395450D46CCB27234F42FC11E5A57A5078",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "C4322BF4BE5D9031B9765BDFCEB02BAF430ECD3A2F918E70E8A7AD9125E7356F"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "97B67A488A6F5C78A6FFAEB6A53E7925CBDEB1423342957B05ABD00E75B5A7C9"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "16AE6B2F3C870A0289C1FE5BA7A7052E27E10D56EBA8D7B9D57928D2A9BD2488"
+        }
+      ]
+    },
+    {
+      "mnemonic": "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+      "passphrase": "TREZOR",
+      "seed": "26E975EC644423F4A4C4F4215EF09B4BD7EF924E85D1D17C4CF3F136C2863CF6DF0A475045652C57EB5FB41513CA2A2D67722B77E954B4B3FC11F7590449191D",
+      "rootPublicKey": "9A78BF9F3264F861F5C6DC24C39A9F8145D7643AA2DE9F3715B0025A539E592C",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "D62B2C7CC51129BE84D00868921B2C34B82CFA9E7F70214A91714DDE960AED5F"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "60162A7B7DAA8FEA1FB659B0E5198325F4930EBFB0C0DD031F16F5958A925DD0"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "112FD4CA02FBE5F91AAA224E48F92DCA096592392B190273E86A74E6ED72E69C"
+        }
+      ]
+    },
+    {
+      "mnemonic": "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+      "passphrase": "TREZOR",
+      "seed": "2AAA9242DAAFCEE6AA9D7269F17D4EFE271E1B9A529178D7DC139CD18747090BF9D60295D0CE74309A78852A9CAADF0AF48AAE1C6253839624076224374BC63F",
+      "rootPublicKey": "DCA8F450D5683B6A18DF768DEDFA466D6F8DE22E0F2BE04375281A7B659E1F05",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "D20B37A796E98594583884E2498EDB09B4F200284B1AA7D7E1C5B401BB3BD5CA"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "14AA7B84D8B7D76F9F375A6A46D08042BB034C375E044F2C8D53B61C3666B445"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "C6A2D0CC6F34F590462E555E64D45066A011C8B2F326F2AA705DC005C53801A3"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+      "passphrase": "TREZOR",
+      "seed": "7B4A10BE9D98E6CBA265566DB7F136718E1398C71CB581E1B2F464CAC1CEEDF4F3E274DC270003C670AD8D02C4558B2F8E39EDEA2775C9E232C7CB798B069E88",
+      "rootPublicKey": "1C63B5DD9A23641D2CA4BAB20049542A7BD376396444CB7EE054763F3406D098",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "C456CBAD014752BADBF993D87186AE157B312BB264A82BEBD1BB4E979284040D"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "D0C1E293CB505CBCA989A56B227D8770400FF231807DF9D4CEFC3864BAA3D846"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "798B1672A97E256FDF2B8D98E8AD8ADA1603D9D33F27D1794FF0BF63EC6C6F3D"
+        }
+      ]
+    },
+    {
+      "mnemonic": "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+      "passphrase": "TREZOR",
+      "seed": "01F5BCED59DEC48E362F2C45B5DE68B9FD6C92C6634F44D6D40AAB69056506F0E35524A518034DDC1192E1DACD32C1ED3EAA3C3B131C88ED8E7E54C49A5D0998",
+      "rootPublicKey": "3E812BE40B8F0AA502F46FB521B4FCADF96B532B2E052EC50921A98426A8E5DC",
+      "childAccounts": [
+        {
+          "path": [44, 43, 0, 0, 0],
+          "publicKey": "7613F26466459729E165C9FE1265359511181AFF471D015623404397A29D62F9"
+        },
+        {
+          "path": [44, 43, 1, 0, 0],
+          "publicKey": "9C15087FFD18EC2290B24256D22278D08C8F96C4361210E3F75E8BDD4D885E3F"
+        },
+        {
+          "path": [44, 43, 2, 0, 0],
+          "publicKey": "622A3EABE103C6B8AC5072784607027FC0B9A7A1D2CB4D1FF2A192C38247805D"
+        }
+      ]
+    }
+  ],
+  "test_net": [
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "passphrase": "",
+      "seed": "5EB00BBDDCF069084889A8AB9155568165F5C453CCB85E70811AAED6F6DA5FC19A5AC40B389CD370D086206DEC8AA6C43DAEA6690F20AD3D8D48B2D2CE9E38E4",
+      "rootPublicKey": "1946E430AB6CA462394AC3CA40FC2F924058B4885B2840A4C692980D2DF0BFB3",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "5AD4795F35641EE324025ACD27F8BCC843B7155F75532D9ACD76242F89EF2851"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "6FB0EC57F0113ECF0354F75350131913696ECF70A266322ABC95D22D43D32EA1"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "079ED4E17B44ACE0A03E38E0BC7FFB19659B80565C0006D720EAD88B62DCFA4A"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank yellow",
+      "passphrase": "",
+      "seed": "878386EFB78845B3355BD15EA4D39EF97D179CB712B77D5C12B6BE415FFFEFFE5F377BA02BF3F8544AB800B955E51FBFF09828F682052A20FAA6ADDBBDDFB096",
+      "rootPublicKey": "A490F34F3BFF87EE2FBA681CAAD465E4096970CC168E041AEAE90588C55E8FDE",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "2A613B4B8CD275CF94CEEF5401228AB50C87616EFEA64237077968DD0A69C793"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "750A78F82F74D6BC34DADF8F24FA19AA0D07ECC367C2B183DF09D26EB40A6E87"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "EB45B3B3140BE3467ECDF192EE235F6AA9DC829A22D9D07D11262C4EACA87AD3"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+      "passphrase": "",
+      "seed": "77D6BE9708C8218738934F84BBBB78A2E048CA007746CB764F0673E4B1812D176BBB173E1A291F31CF633F1D0BAD7D3CF071C30E98CD0688B5BCCE65ECACEB36",
+      "rootPublicKey": "EF457C4B8B746A46FF05DC821266A5A8DFCA95AE831ACF96A99AC12CB2EA0701",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "2369B8040F775F24AE7E48F580E11FB143EB96FA05A7F0D9FD4F60B59A767747"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "707A0F22B4E91CD256E9E775D5D203999308E79DECDF254273753AFCE8CC58A4"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "0260562759F007F967AA5B7A1BE24BC1E38568F07C8E52F019EAD5FD8B673782"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+      "passphrase": "",
+      "seed": "B6A6D8921942DD9806607EBC2750416B289ADEA669198769F2E15ED926C3AA92BF88ECE232317B4EA463E84B0FCD3B53577812EE449CCC448EB45E6F544E25B6",
+      "rootPublicKey": "0FB2631293D992A997051D79A8DDC9479AEA051F97E0ADB0123CBD5734231224",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "30C23AD502DC9BB6D31C30A319182EFE1DC29ADCD9FE91B55146CA1D1B5EC7ED"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "1D457487C2631167C104DB882F31770AC99742F15B8B4450973155E105107E48"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "48107633091083261B0E470FC0EC80B71817D3514334617BB6208000F9A127F8"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+      "passphrase": "",
+      "seed": "4975BB3D1FAF5308C86A30893EE903A976296609DB223FD717E227DA5A813A34DC1428B71C84A787FC51F3B9F9DC28E9459F48C08BD9578E9D1B170F2D7EA506",
+      "rootPublicKey": "8ABB4CC0EFB1B4FD39E2BD2CC4BD7CA9A7BD549BDF4F6B30A71506E6402E290F",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "6CB615F127B3F176BEA58A0BCC14DEB942F7693EB2B1BF0D511230D7ACB384A0"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "EDBF29ADFC9F324181B89501AA68D8837E1AA84DE2A503459AD0C6F87ED6543C"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "186A937A5463D53266F920287BD48B20F7F89EDB023F476444D2A25BACCDEB30"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+      "passphrase": "",
+      "seed": "B059400CE0F55498A5527667E77048BB482FF6DAA16C37B4B9E8AF70C85B3F4DF588004F19812A1A027C9A51E5E94259A560268E91CD10E206451A129826E740",
+      "rootPublicKey": "A572997EAF42DF29B7D043A03CE675BA5E5BB0D891519ED06F8176C998084F52",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "1DED4A73C1C92B9F719EA27CD6D9F914764813533E2515C2F34977A0E1FFDE43"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "6D9980F937996D6B4DA2ACA3A4FEA89DBFDA40FFB551D553A112ECFC76F09472"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "166872D6F399D839D6E457A983FEC888A67B8B5D902B5DCA81A628C8E744B1E3"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+      "passphrase": "",
+      "seed": "04D5F77103510C41D610F7F5FB3F0BADC77C377090815CEE808EA5D2F264FDFABF7C7DED4BE6D4C6D7CDB021BA4C777B0B7E57CA8AA6DE15AEB9905DBA674D66",
+      "rootPublicKey": "A3685884F1B460735E3062D5554FADE7855C7F3AB55A9F32991E18A97CF2607D",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "F9205AF8D12F445D5BAEC432B68B90B54FAB59BA7E437A2BA594A90BFB23CA5D"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "8FD4863A4204E94BEAA0DD3F580AFDE8AE1940305268A648BB6D29111E856213"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "862AF8D794C6F9E53B8C2CBC18C88CD001889263BAE0B6AC7AB1EB9AD8E8F07F"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+      "passphrase": "",
+      "seed": "D2911131A6DDA23AC4441D1B66E2113EC6324354523ACFA20899A2DCB3087849264E91F8EC5D75355F0F617BE15369FFA13C3D18C8156B97CD2618AC693F759F",
+      "rootPublicKey": "710DA9C40BBA433CFF11F26B217464F2CF0786A91B9C9E9964FB1C547A37A87B",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "DFB73F2D478745F0E6702F14131CF9F804173C703E1E33BF349DAFE17FBEFE77"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "AAFD659B4E2EB189312831BF31F1305945DE65F94F4F47C10E0F53F505B87F14"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "5A2E8E53613B0F4F3568DA4427B114CE67BE611240FDE6AD87BF0283B455D75B"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      "passphrase": "",
+      "seed": "408B285C123836004F4B8842C89324C1F01382450C0D439AF345BA7FC49ACF705489C6FC77DBD4E3DC1DD8CC6BC9F043DB8ADA1E243C4A0EAFB290D399480840",
+      "rootPublicKey": "AB96B04A3731993D08CDC049BA8C3D15B86A53D0690FFF57D880C27C23BB2250",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "BAA6148215906BC6FA2A2D0CCFC0EB62750EB18AD4678361F6C32BA219A83A78"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "91797FE70CA4BF78856E200A236EF57E7F6A492D3BB4639E65AB399ADDAE4943"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "E91952E1BD1CBFC28E18BC251848D5A7D3A69690C5326C2C787CF88E645B6250"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+      "passphrase": "",
+      "seed": "761914478EBF6FE16185749372E91549361AF22B386DE46322CF8B1BA7E92E80C4AF05196F742BE1E63AAB603899842DDADF4E7248D8E43870A4B6FF9BF16324",
+      "rootPublicKey": "BBE6CCCAFCE0CCAB61103028EC9D75713BC065ECA88264688D1BB6DF939598E8",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "4F31D8409CF403168FE54774B7837F7A967257B20A9B6DFAD6963F0621A13703"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "C7D1190F55E85B5416AA1A869E268D41D94C166D2F1350AE9449674387D8B636"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "C0718B0F842366E7A4D091B84A0D0ACA34C3F8A4A34579CBEDA39FDC35ADAEF1"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+      "passphrase": "",
+      "seed": "848BBE19CAD445E46F35FD3D1A89463583AC2B60B5EB4CFCF955731775A5D9E17A81A71613FED83F1AE27B408478FDEC2BBC75B5161D1937AA7CDF4AD686EF5F",
+      "rootPublicKey": "1F83065B3EEE4FC911C15C4F2BBBE1DE9014B41DE1211E26EE77ECEF4A0030D1",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "9E382C99EAA8439D705190F54CFFFF1AD80AEC70D8B79B6D6D7CD3A0F48F9C94"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "E93BCE164C464CF25DDA2EF1437E1AF34A667CA641175A4983B81D309A9D0E3E"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "BBCCE45EFF7E1E4E532C98AA7372B80FC3F0BE4C0474077ECB905E704998E828"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+      "passphrase": "",
+      "seed": "E28A37058C7F5112EC9E16A3437CF363A2572D70B6CEB3B6965447623D620F14D06BB321A26B33EC15FCD84A3B5DDFD5520E230C924C87AAA0D559749E044FEF",
+      "rootPublicKey": "FE571EC4B0D2D99D915FA46EBED88D84009E8C91776578212B617DC8B9513FD6",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "8F4C5629803432550FE4F2F42267177BDC86118777A30FE1C1F71F5445AB24EB"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "2C6EFD150D911001EDF9F7C5E9F63BE47BD9C51C20B25D0CF8FD32A0529D4759"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "8B0F103FC4014DB0F7D2FC9AE6D9E55B0F97687CC49D27E29748E5F526EE18B6"
+        }
+      ]
+    },
+    {
+      "mnemonic": "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+      "passphrase": "",
+      "seed": "E2F88A043776C828063D4C3C97173944D32CF847A925B6E40B0B8BD0B4BEAD3BA734BDDA5250D4698B310A71C9934E1A48E562315CE22BF85F89459DF0E73A6C",
+      "rootPublicKey": "45846FF527AFF9BCE616C0B1A6E0D373875D952AB52BF81EF8547DDE53DEA064",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "5076FAE72DC6688533384F22306F530CA64AD6040F2985E0959BC37AEA1A5285"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "E7532CB48085BB39DF8F6F8465BF6AEABE5785AAE437E1DCA37B13401A66D63C"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "67548B6B1F20AA3AE39DF6A3973A2C7ACDE2D5EBC2D86D3480D7BD0E6038DE34"
+        }
+      ]
+    },
+    {
+      "mnemonic": "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+      "passphrase": "",
+      "seed": "31736B4F31612ECE84404C74A5D3B938A092480EB89C11B81491F1A3657EB2FE50024610FBE814DF55913A87EF741020FCF076A75A29AEA0ABA638126BA4C8BB",
+      "rootPublicKey": "EAC40A4E4E0A2956EA6E78B351F8CD51CF7F48737C471F756C01E2728C0E39AD",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "3F56AFCBC7BF153FCC03433920547B6405C29A60E84E8E8707B0031FE841C60F"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "911A3EB0F99E6B396BAB16FFA4C3ED4F8B063AD705ADB89483E03D56B5F93859"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "BC814B26A952FAB56C6B5857A95E3EAB00C00FB0164F084D83663A2BBEAEBA85"
+        }
+      ]
+    },
+    {
+      "mnemonic": "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+      "passphrase": "",
+      "seed": "17E4B5661796EEFF8904550F8572289317ECE7C1CC1316469F8F4C986C1FFD7B9F4C3AEAC3E1713FFC21FA33707D09D57A2ECE358D72111EF7C7658E7B33F2D5",
+      "rootPublicKey": "30BA1AA120344D55A9C24BCD221DC09C0361C081B84EBED015C554F446854BB6",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "A7E473581026724765780B1D19473E2BD5B4B5275F0CE9E944DFFAF164EE9E10"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "C6E4B48BE4B64EB1D401A610E13D555DE7E22B83227EEF9F20B5B6FCE99BE10A"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "5634F33EE6CB247C31C2D1141AA6932F31DD0B47B866879EEC1821F0E3C14441"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scheme spot photo card baby mountain device kick cradle pact join borrow",
+      "passphrase": "",
+      "seed": "00E1E39A39E23735ADAB690D0FFBEFDA6CACC063B4A5FCC605DE060BD370ADC54C94370D966B9A3FAE5ED16BD58A02224CBEFCA4146A083951B70BE2A2CE3DCC",
+      "rootPublicKey": "A5AE606DD5F0D8218BF503FB2B57B3A6D3C76A332377101BEB00EBB2C8C81022",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "5539FF990BE029CBAEFCC5239F5C4EDBA99690FB47362A851487036D96719901"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "D09EDC05F29BA7F09C1D193D94EEBF70A9C00700601DF993B69AE4610E952716"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "0996F6A5BE6C8BE869952459572CEE3908AAB90DD9C327F3F306A1005E6455B2"
+        }
+      ]
+    },
+    {
+      "mnemonic": "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+      "passphrase": "",
+      "seed": "E893FC34FA2A78CEAAEA78C246B69257AD283FA538D88F3C4520BEB618A2062B8EC4920ED1793FFF6AD443523ED18C03DA433004D0A1E9497E194621607BC9E2",
+      "rootPublicKey": "7A8222ECD77EE0E7A9BB09EFC2F4FC285614462EBE430C457E6012A4388860CB",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "222B78CECC6BCD11476BF5DAE5F4FDA6233249C66636F828B5A8B5F0921460A8"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "5133519CCB0B6A714A59ED9F0F4C67BAE588D18F39FCBA02A6DA206B647CBE73"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "D407180BCE06F3D6A59F2E34D829F9F5959C9F4C2AE09A40A7C38F849E7A1606"
+        }
+      ]
+    },
+    {
+      "mnemonic": "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+      "passphrase": "",
+      "seed": "3E066D7DEE2DBF8FCD3FE240A3975658CA118A8F6F4CA81CF99104944604B05A5090A79D99E545704B914CA0397FEDB82FD00FD6A72098703709C891A065EE49",
+      "rootPublicKey": "BD31401335F76E04C31F6E99B5BE438E6CA987E0F5F450E4E845BE566FA73DA0",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "52DC21A8584D669C691F57823DF94E3864B2D970A9BE8D2EB245F4B49A01CB0F"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "D6733D19A76A36369B87DDD13AFA192CD470AB2939DBC8CBCA68161AD0B1767D"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "5A949C35544E767CF68B0D93EC7F5F18195AA7538868B22C4C6D9805F44D3FC2"
+        }
+      ]
+    },
+    {
+      "mnemonic": "cat swing flag economy stadium alone churn speed unique patch report train",
+      "passphrase": "",
+      "seed": "7EA73B3A398F8A71F7DDE589D972B0358D3FA8B9E91317ECC544E42752B1BB251A1926B1F4C69EEC0A80C0396AA0F7DF29F7D73411D3106EBA539F3D584FCDF8",
+      "rootPublicKey": "E9222C652FC20E338874406554DE00ADD62B69F2A43FB6B30E731311724E97AC",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "28427FD848DFE0099A8F3B5D799B57BB0EA11BD48EE2BF63BDCCC15B038C4B91"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "57EACDE5FF8EE6ABC2B5154EB60D27B280EFD2FA688553BEED679EFCF94D8D98"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "9528AA5F008E6962E1E05D8D79ACD8F0C25B4B06DC73403481AAB6EB919F37A9"
+        }
+      ]
+    },
+    {
+      "mnemonic": "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+      "passphrase": "",
+      "seed": "D0CA8861283A7124515E825B7A06DE8E0AD0DD5AC7888013EFE6E3C300D4745BBD2C729F3355D769D23718579E7B735999A8F0B38E22B5BFF45C9085AF449056",
+      "rootPublicKey": "29DA443A7C8B54DD031D31B9B46F1ABE9ACA9AA9B536816B9BAE5F78BDFE5E99",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "3A5E4646CEEB1EFD5010690B1DF0946204F6F25A4700FD3778211390617D95B9"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "6CB9C5A7C51FFBA64D11952ACFF2C850BCEFA94D45937A1B0500C37D04620C7F"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "F35AB3CD94FED5686C42786B72142904AA170CEA1B903FB2C27BC73886C4361F"
+        }
+      ]
+    },
+    {
+      "mnemonic": "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+      "passphrase": "",
+      "seed": "FC795BE0C3F18C50DDDB34E72179DC597D64055497ECC1E69E2E56A5409651BC139AAE8070D4DF0EA14D8D2A518A9A00BB1CC6E92E053FE34051F6821DF9164C",
+      "rootPublicKey": "5F19703C36821F5673754044EA108FBBD7EAE38FFDC2B71190F182C67E255822",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "89F9F382782D5DDA55159B69519F6DF160E8B0230ABFADB4DE8058A8480E283F"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "93D906B5D19F26F3EFA1F74319658ECB9B9922040A6E924943F8A8FFDBE6863F"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "B01A5D5EA443C2200C04B72E69B1E464FE325CB8BF582B17874B24A6FD80759C"
+        }
+      ]
+    },
+    {
+      "mnemonic": "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+      "passphrase": "",
+      "seed": "E2D7F9A462875C1325F44F321392EDC8EAAFEBF1547C89D72D10B41B4EE23AF3FB0AB010F39F5CBEA3B3AA671161B58262B6A508BCBE2D34EE272A942534D45F",
+      "rootPublicKey": "D1DDE656E66BBB185373AB84F42BD286C3BADF84651EA2AD006C1EB314E453F8",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "6210D2EFA051E41308D5C0B077387166D312327EA85500BE751D47E52CA2798C"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "8C9BD372DF83C36CE664C286DFFFE6F66267DFC47D2A43ACAB266D199AF6E261"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "83F6A1C985EFA6A2994471AA223F10102AE103CD9E61279609533399AAE04D61"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+      "passphrase": "",
+      "seed": "A555426999448DF9022C3AFC2ED0E4AEBFF3A0AC37D8A395F81412E14994EFC960ED168D39A80478E0467A3D5CFC134FEF2767C1D3A27F18E3AFEB11BFC8E6AD",
+      "rootPublicKey": "4124D3C1941586C07EDCBDBED1B7DB107C09A56B8B2A258DDD9E359651F3572F",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "1414B392BBF216D11E290CDEBA08C3F159F885427B80CA7C98172074A103868F"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "2B1CF4AFB4E7305FF4C0537A3B3ADE4FB87969988A2CE775E31C9C1184FE800B"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "FDA39B6C7C94F2CE3C0B360D160F450B1F14292C183187EA2B08EA4E44AD3D9C"
+        }
+      ]
+    },
+    {
+      "mnemonic": "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+      "passphrase": "",
+      "seed": "B873212F885CCFFBF4692AFCB84BC2E55886DE2DFA07D90F5C3C239ABC31C0A6CE047E30FD8BF6A281E71389AA82D73DF74C7BBFB3B06B4639A5CEE775CCCD3C",
+      "rootPublicKey": "006538A4E58402C812DC9A046F5225148BD3FC4EFC84948825E4F7F3116F4B14",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "08D89366F2FCED6DD2B63D54B19A07DCD529E646B1AF411C9970D0F402B4A535"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "6A95B208D1DE98727412238C35FF9E35431E3EC357D2CC3CADE3E7CC692581FE"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "6F12A5CCF538FD2D0245A8F66239AD5878F5DB690787296E9ADC0E974364D8FD"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "passphrase": "TREZOR",
+      "seed": "C55257C360C07C72029AEBC1B53C05ED0362ADA38EAD3E3E9EFA3708E53495531F09A6987599D18264C1E1C92F2CF141630C7A3C4AB7C81B2F001698E7463B04",
+      "rootPublicKey": "7AD06DBDDB30719117113D532238150FCF77ECDB6EB4754A5F98ED4D3CD9185D",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "72EB3BAFB27DCBDD02DF04E162FCFB8988ABD994AD30AA680F37CF14F1423BF4"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "515394040EB217AB6BAF3E4EC91DBEEBBA7601AEA965E7D8A0870C1B586EE073"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "6911B4246E8AA255CC61F19A4B06B8F6912D4C514B6CC7187614B3E149EE9CDC"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank yellow",
+      "passphrase": "TREZOR",
+      "seed": "2E8905819B8723FE2C1D161860E5EE1830318DBF49A83BD451CFB8440C28BD6FA457FE1296106559A3C80937A1C1069BE3A3A5BD381EE6260E8D9739FCE1F607",
+      "rootPublicKey": "2DF1BA3A3A47D0E2E7CC928C91F9886733B8C4C89B59170C97F682E2328DF457",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "C76522DAEE49907BAFC4BD929CA317D581EAA139DD3AEA019B7AEDDE7512B2DC"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "C93AE41D7FA355410ABCECC7E3CFC47C374B929512AC1B6D214DC37E49509FF9"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "C4595ECABAFCC963FB0BBEF20E897ECA0A86A161EEE7470A90A733CE15930261"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+      "passphrase": "TREZOR",
+      "seed": "D71DE856F81A8ACC65E6FC851A38D4D7EC216FD0796D0A6827A3AD6ED5511A30FA280F12EB2E47ED2AC03B5C462A0358D18D69FE4F985EC81778C1B370B652A8",
+      "rootPublicKey": "670C0A47F164520A99AC03309E71FC2361ED831BCB02DE54F38459BBBA42CA9C",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "5F054CFBE8EFA9820088A4FD3302253240E004514A759185F5BE2BA874B814D1"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "C80717325EBBBB8EF5CFE687B62563FA045435565B703A7A66B465C662808C3C"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "922A28C7159B41D609BF9AD46CC9CDE17B92C09820ED2CDDBD62A3D668A92240"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+      "passphrase": "TREZOR",
+      "seed": "AC27495480225222079D7BE181583751E86F571027B0497B5B5D11218E0A8A13332572917F0F8E5A589620C6F15B11C61DEE327651A14C34E18231052E48C069",
+      "rootPublicKey": "4F46B3A23C0DE9C903B1BF918BE7628B196AB3BF0DA48F3423375838769D71C0",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "8A401054DF03BA52036A6CECC33ECC4AB0DBF014AB657CC4FF6A72BA6BB9CA69"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "BE26C8ECADECC749E9DE8A83486747196AC55B9D7EE86AA043996B7E28E80E3F"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "1113629307B7D9636500FDB89966A20D3B444F587BA1F9BB4AF37FEA268A1E30"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+      "passphrase": "TREZOR",
+      "seed": "035895F2F481B1B0F01FCF8C289C794660B289981A78F8106447707FDD9666CA06DA5A9A565181599B79F53B844D8A71DD9F439C52A3D7B3E8A79C906AC845FA",
+      "rootPublicKey": "FBC289808A078ACB5C03045659B2EA564DCBAB9E378C8F6799B4367E4789361B",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "A5CE501357BB7CD7B32C369D2DC955CAFCBA20DEAA4D1740680EBE77CC68BBFB"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "FD9AFD77A8A254B00EDFF51088281E5B9891CEB46E511333629A086D384F8708"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "5A429E5ED39A0E9FCEA2DECB56E3744C1D4A199F892E37CB575E2DB69847F41F"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+      "passphrase": "TREZOR",
+      "seed": "F2B94508732BCBACBCC020FAEFECFC89FEAFA6649A5491B8C952CEDE496C214A0C7B3C392D168748F2D4A612BADA0753B52A1C7AC53C1E93ABD5C6320B9E95DD",
+      "rootPublicKey": "EDB02192139FDC70FF7579A9BA622D4461E65EC3B9B8EA98212FCD726C8DCBAF",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "DFB753A6F3F4742223C5003AC932035C08CE2B078F9ECCF396CE5DD626791743"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "8EEBF68A6179C6E2F5AD89705222455E87628B0B4BA21341BA6E96DF61FEF541"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "A18CC9121B68B0C66F55B7B30395EC5463EB63EE7D3FA5A62F387E9A7FD76A4E"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+      "passphrase": "TREZOR",
+      "seed": "107D7C02A5AA6F38C58083FF74F04C607C2D2C0ECC55501DADD72D025B751BC27FE913FFB796F841C49B1D33B610CF0E91D3AA239027F5E99FE4CE9E5088CD65",
+      "rootPublicKey": "08271FAE4ED37A63CC5950510A9F8894F86B25D72B0E21509A7AB84E2400E3FF",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "478ADE93C238D834328066B2F42C7833F5CE366596B21E69C64617D18D84EFCD"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "7B15A1C4EFEAA4CA4C918EA3BBE0C15755456E709B99F1AFEC1771D4849004AC"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "B5DC28F8C31ACF5ECCA8DCE12520CDA46F42C08065545117EA3ABC251ED4D524"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+      "passphrase": "TREZOR",
+      "seed": "0CD6E5D827BB62EB8FC1E262254223817FD068A74B5B449CC2F667C3F1F985A76379B43348D952E2265B4CD129090758B3E3C2C49103B5051AAC2EAEB890A528",
+      "rootPublicKey": "5FFC235559503539DC720F7151225B05AA84D1ED289CC5B0097C6D6C21185305",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "0C833AC72BC98D6715911B23D8BAAFBC789769C9DB7007AE23BDCA6F7285E2E3"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "020A88F7396FCFF4496F3543414BC28B775CAC55B6203E665CB1172413B8567E"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "D8E9151777DDF71060C07DB18784F33275A191CAF6B0CA1A922BFD6520DF4257"
+        }
+      ]
+    },
+    {
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      "passphrase": "TREZOR",
+      "seed": "BDA85446C68413707090A52022EDD26A1C9462295029F2E60CD7C4F2BBD3097170AF7A4D73245CAFA9C3CCA8D561A7C3DE6F5D4A10BE8ED2A5E608D68F92FCC8",
+      "rootPublicKey": "5451901B0BD5DF9C7E2CF87876146246A2D847E57306E302DDD7C9FA8B8C9E9A",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "626DBA7735F36DC07353BCA78AAB7CA450B2C4B32F7BCA75FC1E15522C9978D9"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "69905E519D4062D8BEB5FA4D490F0B239128D72F0A5A00FB88D74753F850B35D"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "DA947EA7A503A7EEEAD61609ABC261AF04C5EA449D10DE6672BBB24AFBDFBD6A"
+        }
+      ]
+    },
+    {
+      "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+      "passphrase": "TREZOR",
+      "seed": "BC09FCA1804F7E69DA93C2F2028EB238C227F2E9DDA30CD63699232578480A4021B146AD717FBB7E451CE9EB835F43620BF5C514DB0F8ADD49F5D121449D3E87",
+      "rootPublicKey": "32479AAEBB123F993AE9E4239E3C889913F7F2182AE9696B9D95DCA1A55FD5B2",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "AB43DD939DD90006CB7D2CAA37308D1AF49B4AEA046A11FD80119ED8CDC252A9"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "AAEFA80E76B01B63347329CB75B25169654D734F1A583FC1FFA42AB725E589B0"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "DE5B8C4D44E59289F8EC1BA5A7458AD062DBD4F46DEF4054DBA77C8D1F310A86"
+        }
+      ]
+    },
+    {
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+      "passphrase": "TREZOR",
+      "seed": "C0C519BD0E91A2ED54357D9D1EBEF6F5AF218A153624CF4F2DA911A0ED8F7A09E2EF61AF0ACA007096DF430022F7A2B6FB91661A9589097069720D015E4E982F",
+      "rootPublicKey": "6B66F2311E3D3D0E7EE74C95A3D9D33CF3E02C80AA4DFBC5F013EBED2D045229",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "D2B767A6C316E9C9196F50FD20BC65DD6A4B19FA36CD8F1EFBCCE4AAE4692B66"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "F2BBEBF23B53C0776C94A57F9B5243A46CC64B66973447372564226BA928FB37"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "F8D1B1DE887DAD3B49B3343D787649E8A545FC4A031D7DC61FE82E20C2A19017"
+        }
+      ]
+    },
+    {
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+      "passphrase": "TREZOR",
+      "seed": "DD48C104698C30CFE2B6142103248622FB7BB0FF692EEBB00089B32D22484E1613912F0A5B694407BE899FFD31ED3992C456CDF60F5D4564B8BA3F05A69890AD",
+      "rootPublicKey": "C5A77E179CD82D28CC3878FB560B0636C199AEBB6D6A51A9A92A7EBFD15E66A9",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "685D3F3E0A786A1FC29F029B25C422DE922FE75EA639D24F38C20E55F5339AEE"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "448A1CBD8D1C81F51F3DA962BA5C1F3D9AE257AF81ADD83D96549C2A91610BE8"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "46B17F3FFB1B4DD3DC41123148E7FF0B28770FEE4648F39CC833A6D43FA3E693"
+        }
+      ]
+    },
+    {
+      "mnemonic": "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+      "passphrase": "TREZOR",
+      "seed": "274DDC525802F7C828D8EF7DDBCDC5304E87AC3535913611FBBFA986D0C9E5476C91689F9C8A54FD55BD38606AA6A8595AD213D4C9C9F9ACA3FB217069A41028",
+      "rootPublicKey": "7F12BA318928F9737E8C43C099160414917BE4C5422DBBFF207FCCBDC62B79BD",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "0B411E227A4F4EC503328E63FAE6514C0B413527D756F5AAD36FBE963C9CE893"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "2D26AF3E00C0F22E91D2B4834112DEEF0AFC75698069E2A4AD7C81422C2A7262"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "1AD836A08C0F9E8EEF1D673E12473BCCA22F8AB47B1A7A4D82371A89B7D44907"
+        }
+      ]
+    },
+    {
+      "mnemonic": "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+      "passphrase": "TREZOR",
+      "seed": "628C3827A8823298EE685DB84F55CAA34B5CC195A778E52D45F59BCF75ABA68E4D7590E101DC414BC1BBD5737666FBBEF35D1F1903953B66624F910FEEF245AC",
+      "rootPublicKey": "CD455406549E2404FC996D027CF111B4461A04375A6A4A3B6C4D44A932B4FC3C",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "21CDEBCA55CF8A5F633968150B28D97AD30FF71F28D8A321154416B1254A406A"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "7FCB2E6495B8AE5260D577E45C5D310D77BD739C4CF678772A58344FA83B32F5"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "B5DBFDFCE8E311DF76771C0E54C0C66C87AA1F9505577449837E1BBF4A30083B"
+        }
+      ]
+    },
+    {
+      "mnemonic": "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+      "passphrase": "TREZOR",
+      "seed": "64C87CDE7E12ECF6704AB95BB1408BEF047C22DB4CC7491C4271D170A1B213D20B385BC1588D9C7B38F1B39D415665B8A9030C9EC653D75E65F847D8FC1FC440",
+      "rootPublicKey": "0D8147B06AA664684AB144DFA2835B1F296053D520F8B559CF9F4DEBD4EE2A92",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "F1D292C85205738EE5DCD8BE6EA9033F8FB88CCECFB986BF213773E380BC2893"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "43D5416E2506326F0CFA6641DD9FE1D6A3D3435CA05A82420AC6E8D1ADCE0C40"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "8F428EAF458FA0EC60C725B926D3CD71C5C1F6590C650B72BE999439708A066E"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scheme spot photo card baby mountain device kick cradle pact join borrow",
+      "passphrase": "TREZOR",
+      "seed": "EA725895AAAE8D4C1CF682C1BFD2D358D52ED9F0F0591131B559E2724BB234FCA05AA9C02C57407E04EE9DC3B454AA63FBFF483A8B11DE949624B9F1831A9612",
+      "rootPublicKey": "3C85C318EF2A82DAF5BECCF65E0B8611C6E069AA0B241EA33AC28696E8C96B45",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "434E8E9B39F316ECEF20483B537C6192868A9A06D4BC6F9CB7797F91E947FFAE"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "2937C2B9655DB9D145E764D2366199A29000B413034D5F3BF1878DAD23AED99E"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "0F50341E603F84F682666D7501D995F1F329837A70E4306888FF06111271F8F7"
+        }
+      ]
+    },
+    {
+      "mnemonic": "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+      "passphrase": "TREZOR",
+      "seed": "FD579828AF3DA1D32544CE4DB5C73D53FC8ACC4DDB1E3B251A31179CDB71E853C56D2FCB11AED39898CE6C34B10B5382772DB8796E52837B54468AEB312CFC3D",
+      "rootPublicKey": "60481CD4FC97BCB4AC74D57DF9034CA650046C293FCF20CDDF40207ED6C0D955",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "E12499C8F579F14100BBBF0D1AAA64C8B6F304CC2C5A4BB9F47661DF4E1F2DDF"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "7C39D3AA9CE0B9235D6626FA5128E4BD5382B301E7FCD8579E84311300E82C66"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "2595ECA952960943FF85BB8194518DB56B10F7838AF0CC126CCA285A3A4EB6A0"
+        }
+      ]
+    },
+    {
+      "mnemonic": "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+      "passphrase": "TREZOR",
+      "seed": "72BE8E052FC4919D2ADF28D5306B5474B0069DF35B02303DE8C1729C9538DBB6FC2D731D5F832193CD9FB6AEECBC469594A70E3DD50811B5067F3B88B28C3E8D",
+      "rootPublicKey": "8127A3912B017EFE8C7DFCC9C0F6DD8D46DCA472C314C666C33DA88BC27D1171",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "D71C38A65880B1615B5453D7BF07A3AD7708B954FDBAA5A78BAD4048F97BCC6B"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "558445E31B3C58F28564CA112DF717EAD126437E6C8AD48F125A70209E0D9E47"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "681D7422CCBB29013B650D9C7D1B58F1A811BB8535C2A526FDAE5636A352C15A"
+        }
+      ]
+    },
+    {
+      "mnemonic": "cat swing flag economy stadium alone churn speed unique patch report train",
+      "passphrase": "TREZOR",
+      "seed": "DEB5F45449E615FEFF5640F2E49F933FF51895DE3B4381832B3139941C57B59205A42480C52175B6EFCFFAA58A2503887C1E8B363A707256BDD2B587B46541F5",
+      "rootPublicKey": "EE3B4E609064B16C43DF1FE239B7F2D331F94736D564A0CD257ABC2AA21245A2",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "C9E6DC27EB23970D95D970BB1850D8EB7C1733531DAC1AA88541B9364F025913"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "E031598FFEB8D962E95D10A134AB98CFC547E43D8F9F74A6CA4C9EE91324893B"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "83859C75D935B30DA83A333EDA151A7E6B85E592F1E93C3845F00686884AE453"
+        }
+      ]
+    },
+    {
+      "mnemonic": "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+      "passphrase": "TREZOR",
+      "seed": "4CBDFF1CA2DB800FD61CAE72A57475FDC6BAB03E441FD63F96DABD1F183EF5B782925F00105F318309A7E9C3EA6967C7801E46C8A58082674C860A37B93EDA02",
+      "rootPublicKey": "45AFE2F6FB864E4F46CAA4E5064CCA395450D46CCB27234F42FC11E5A57A5078",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "4296BC618013E2D7C3ED62B58D6F8C33C37CB6813CCA185EB338C60B24FE1CD9"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "F6FF346BFAE48824B6E49B745D401E790D066406DEBB178F0A596CB7D4B77EF9"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "C86E8ECF34767161DB4F556877E00F80C38B35830FEF36CFA91E3D2A167C61B9"
+        }
+      ]
+    },
+    {
+      "mnemonic": "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+      "passphrase": "TREZOR",
+      "seed": "26E975EC644423F4A4C4F4215EF09B4BD7EF924E85D1D17C4CF3F136C2863CF6DF0A475045652C57EB5FB41513CA2A2D67722B77E954B4B3FC11F7590449191D",
+      "rootPublicKey": "9A78BF9F3264F861F5C6DC24C39A9F8145D7643AA2DE9F3715B0025A539E592C",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "60A49A628A8C8612A69B094D714C4A14A84E5E392A76A80CA951B99235F7C158"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "7F62AE20C2E31E7209CA46B39841AD13D03C18467D0A639E9C94F0BE7069CEE4"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "472064248B6F238F6A452EA69485E044E33C0CF30D65495101610193DEE69C7E"
+        }
+      ]
+    },
+    {
+      "mnemonic": "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+      "passphrase": "TREZOR",
+      "seed": "2AAA9242DAAFCEE6AA9D7269F17D4EFE271E1B9A529178D7DC139CD18747090BF9D60295D0CE74309A78852A9CAADF0AF48AAE1C6253839624076224374BC63F",
+      "rootPublicKey": "DCA8F450D5683B6A18DF768DEDFA466D6F8DE22E0F2BE04375281A7B659E1F05",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "64AFBEDF96546518367413D7BA9A350C2FF90C140CFA7C4BABB7033068EAD23A"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "197C751E906891C43920AAA6BABD3138C2AC2FA3D41E46C48374FB742161B2FB"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "EABF3427D5F73FC2AEC49A0265A7FE72BBE363ECC161C73C6DF67E997BA5DEED"
+        }
+      ]
+    },
+    {
+      "mnemonic": "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+      "passphrase": "TREZOR",
+      "seed": "7B4A10BE9D98E6CBA265566DB7F136718E1398C71CB581E1B2F464CAC1CEEDF4F3E274DC270003C670AD8D02C4558B2F8E39EDEA2775C9E232C7CB798B069E88",
+      "rootPublicKey": "1C63B5DD9A23641D2CA4BAB20049542A7BD376396444CB7EE054763F3406D098",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "23B04230BFC6F40C2543B1D100B39CA0DAA11CC9F9C54A71A209E9ACEB658C24"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "79509CCBF7EFA25FCE904CE0740872BB3C592494CCCE7CBDC70C4AF2779873E5"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "0BF67AF79617E36C1F7B35946558A9BC6D7AEABDBF69AD044BBDE67D559C6501"
+        }
+      ]
+    },
+    {
+      "mnemonic": "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+      "passphrase": "TREZOR",
+      "seed": "01F5BCED59DEC48E362F2C45B5DE68B9FD6C92C6634F44D6D40AAB69056506F0E35524A518034DDC1192E1DACD32C1ED3EAA3C3B131C88ED8E7E54C49A5D0998",
+      "rootPublicKey": "3E812BE40B8F0AA502F46FB521B4FCADF96B532B2E052EC50921A98426A8E5DC",
+      "childAccounts": [
+        {
+          "path": [44, 1, 0, 0, 0],
+          "publicKey": "0DBDDBE0D92BF6D9788256F2D740D7686C890B8E0FDC7D50CFB4AA6253FA835A"
+        },
+        {
+          "path": [44, 1, 1, 0, 0],
+          "publicKey": "84F062F9F02F0687B65DA783BD905D74D34F1418079F9A5CE676FD3022AE73DD"
+        },
+        {
+          "path": [44, 1, 2, 0, 0],
+          "publicKey": "7F4845528997111938679DBD2025A97557AAD343F7C3AF8FD9346F99F7494216"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
regenerated all BIP39 symbol tests for NIS1, so mnemonics should match

```
# symbol
 BIP32 derivation test: successes 140
 BIP39 derivation test: successes 96

# nis1
 BIP32 derivation test: successes 96
 BIP39 derivation test: successes 96
```